### PR TITLE
Remove unnecessary apk commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM alpine:3
 
-# hadolint ignore=DL3018
-RUN apk update --no-cache \
- && apk add --no-cache openssh-client openssh-keygen shadow pacman pacman-makepkg \
- runuser git grep binutils gcc \
- && rm -rf /var/cache/apk/*
+RUN apk add --no-cache openssh-client openssh-keygen shadow pacman pacman-makepkg \
+ runuser git grep binutils gcc
 
 COPY entrypoint.sh /entrypoint.sh
 COPY build.sh /build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache openssh-client openssh-keygen shadow pacman pacman-makepkg \
  runuser git grep binutils gcc
 


### PR DESCRIPTION
`apk add --no-cache` already updates repositories index before installing and removes `/var/cache/apk/*` at the end.